### PR TITLE
eval vs exec

### DIFF
--- a/install-gcc-workaround.sh
+++ b/install-gcc-workaround.sh
@@ -13,7 +13,7 @@ if [ "$(uname)" == 'Linux' ]; then
 
     if [ $MAJOR_VERSION -ge $MAJOR_VERSION_TO_PATCH ]; then
         echo "#! $SH" >> $cur__bin/gcc
-        echo "eval $CC -fcommon '\"\$@\"'" >> $cur__bin/gcc
+        echo "exec $CC -fcommon '\"\$@\"'" >> $cur__bin/gcc
         chmod +x $cur__bin/gcc
     fi
 fi


### PR DESCRIPTION
gcc should be quick to exec but in case of multiple execution we have some more mb taken without utility: I just read https://jeapostrophe.github.io/2012-05-28-exec-vs--post.html